### PR TITLE
Update Travis to automatically invalidate cache when deploying.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ deploy:
   skip_cleanup: true
   local_dir: site
   acl: public_read
+  cache_control: "max-age=86400"
 after_deploy:
   # Delete any old files from the S3 bucket.
   - aws s3 sync site/ s3://$AWS_S3_BUCKET --acl public-read --exclude "*.py*" --delete
+  # Allow `awscli` to make requests to CloudFront.
+  - aws configure set preview.cloudfront true
+  # Invalidate every object.
+  - aws cloudfront create-invalidation --distribution-id $AWS_CF_DISTRIBUTION_ID --paths "/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache: pip
 install:
   - pip install awscli
   - pip install mkdocs
-  - pip install mkdocs-material
+  - pip install mkdocs-material==0.2.4
 script:
   - mkdocs build --clean
 deploy:


### PR DESCRIPTION
This will make sure the changes become visible when we deploy, rather than waiting for the normal cache expiry.

I already added the appropriate environment vars to Travis, and updated the IAM role appropriately.