### PR TITLE
Add an 'after an incident' page, and move some items into there.

### DIFF
--- a/docs/after/after_an_incident.md
+++ b/docs/after/after_an_incident.md
@@ -1,13 +1,13 @@
 Information on what to do after a major incident. Our followup and after action review procedures.
 
 ## Followup Actions for Response Roles
-Each of our response roles will have a few minor followup actions after an incident. These are generally lightweight actions that ensure we organize information and followup with customers appropriately.
+In addition to any direct followup items generated from an incident, each of our response roles will have a few standard followup tasks. These are generally lightweight actions that ensure we organize information and followup with customers appropriately.
 
 ### Steps for Incident Commander
 
 1. Create the post-mortem page from the template, and assign an owner to the post-mortem for the incident.
 
-1. Send out an internal email explaining that we had a major incident, provide a link to the post-mortem.
+1. Send out an internal email to the relevant stakeholders explaining that we had an incident, provide a link to the post-mortem.
 
 1. Occasionally check on the progress of the post-mortem to ensure that it is completed within the desired time frame.
 
@@ -18,7 +18,7 @@ There are no additional steps after an incident is resolved. However the IC may 
 
 1. Review the chat communications and extract any relevant items from key events.
 
-1. Collect all `TODO` items and provide them to the post-mortem owner.
+1. Collect all `TODO` items and add them to the post-mortem.
 
 ### Steps for Subject Matter Experts
 
@@ -34,7 +34,7 @@ There are no additional steps after an incident is resolved. However the IC may 
 ## Reviewing the Incident
 It's important that we review the incident in detail to see exactly what went wrong, why it went wrong, and what we can do to make sure it doesn't ever happen again. These take many names; after-action reviews, incident review, followup review, etc. We use the term post-mortem.
 
-You can read all about our [post-mortem process](post_mortem_process.md), which will go over this in a lot more detail.
+You can read all about our [post-mortem process](post_mortem_process.md), which goes over this in more detail.
 
 ## Reviewing the Process
 As well as reviewing the incident, it's important to review our process. Did we handle the incident well, or are there things we could have done better?

--- a/docs/after/after_an_incident.md
+++ b/docs/after/after_an_incident.md
@@ -32,7 +32,7 @@ There are no additional steps after an incident is resolved. However the IC may 
 
 
 ## Reviewing the Incident
-It's important that we review the incident in detail to see exactly what went wrong, why it went wrong, and what we can do to make sure it doesn't ever happen again. These take many names; after-action reviews, incident review, followup review, etc. We use the term post-mortem.
+It's important that we review the incident in detail to see exactly what went wrong, why it went wrong, and what we can do to make sure it doesn't happen again. These take many names; after-action reviews, incident review, followup review, etc. We use the term post-mortem.
 
 You can read all about our [post-mortem process](post_mortem_process.md), which goes over this in more detail.
 

--- a/docs/after/after_an_incident.md
+++ b/docs/after/after_an_incident.md
@@ -1,0 +1,44 @@
+Information on what to do after a major incident. Our followup and after action review procedures.
+
+## Followup Actions for Response Roles
+Each of our response roles will have a few minor followup actions after an incident. These are generally lightweight actions that ensure we organize information and followup with customers appropriately.
+
+### Steps for Incident Commander
+
+1. Create the post-mortem page from the template, and assign an owner to the post-mortem for the incident.
+
+1. Send out an internal email explaining that we had a major incident, provide a link to the post-mortem.
+
+1. Occasionally check on the progress of the post-mortem to ensure that it is completed within the desired time frame.
+
+### Steps for Deputy
+There are no additional steps after an incident is resolved. However the IC may ask for your help with their steps.
+
+### Steps for Scribe
+
+1. Review the chat communications and extract any relevant items from key events.
+
+1. Collect all `TODO` items and provide them to the post-mortem owner.
+
+### Steps for Subject Matter Experts
+
+1. Add any notes you think are relevant to the post-mortem.
+
+### Steps for Customer Liaison
+
+1. Reply to any customer enquiries we received about the incident.
+
+1. Follow the post-mortem progress, and update our status page with the external message once it is available.
+
+
+## Reviewing the Incident
+It's important that we review the incident in detail to see exactly what went wrong, why it went wrong, and what we can do to make sure it doesn't ever happen again. These take many names; after-action reviews, incident review, followup review, etc. We use the term post-mortem.
+
+You can read all about our [post-mortem process](post_mortem_process.md), which will go over this in a lot more detail.
+
+## Reviewing the Process
+As well as reviewing the incident, it's important to review our process. Did we handle the incident well, or are there things we could have done better?
+
+This review isn't very formal yet, and typically involves a few of the incident commanders getting together to discuss how we might have done things differently, or if there are any tweaks we can make to our incident response process.
+
+If you're interested in joining these meetings, just let one of the incident commanders know and we'll be sure to invite you.

--- a/docs/during/during_an_incident.md
+++ b/docs/during/during_an_incident.md
@@ -62,9 +62,7 @@ Resolve the incident as quickly and as safely as possible, use the Deputy to ass
     * Identify any post-incident clean-up work.
     * You may need to perform debriefing/analysis of the underlying root cause.
 
-1. (After call ends) Create the post-mortem page from the template, and assign an owner to the post-mortem for the incident.
-
-1. (After call ends) Send out an internal email explaining that we had a major incident, provide a link to the post-mortem.
+1. Once the call is over, you can start to follow the steps from [After an Incident](/after/after_an_incident.md).
 
 ## Steps for Deputy
 You are there to support the IC in whatever they need.
@@ -80,6 +78,8 @@ You are there to support the IC in whatever they need.
 
 1. Follow instructions from the Incident Commander.
 
+1. Once the call is over, you can start to follow the steps from [After an Incident](/after/after_an_incident.md).
+
 ## Steps for Scribe
 You are there to document the key information from the incident in Slack.
 
@@ -91,6 +91,8 @@ You are there to document the key information from the incident in Slack.
 
 1. Follow instructions from the Incident Commander.
 
+1. Once the call is over, you can start to follow the steps from [After an Incident](/after/after_an_incident.md).
+
 ## Steps for Subject Matter Experts
 You are there to support the incident commander in identifying the cause of the incident, suggesting and evaluation repair actions, and following through on the repair actions.
 
@@ -101,7 +103,7 @@ You are there to support the incident commander in identifying the cause of the 
 
 1. Follow instructions from the incident commander.
 
-1. (Optional) Once the call is over and post-mortem is created, add any notes you think are relevant to the post-mortem page.
+1. Once the call is over, you can start to follow the steps from [After an Incident](/after/after_an_incident.md).
 
 ## Steps for Customer Liaison
 Be on stand-by to post public facing messages regarding the incident.
@@ -110,4 +112,4 @@ Be on stand-by to post public facing messages regarding the incident.
 
 1. Follow instructions from the Incident Commander.
 
-1. (After call ends) Follow the post-mortem progress, and update our status page with the external message once it is available.
+1. Once the call is over, you can start to follow the steps from [After an Incident](/after/after_an_incident.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ Information and processes during a major incident.
 
 Our followup processes, how we make sure we don't repeat mistakes and are always improving.
 
+* [After an Incident](after/after_an_incident.md) - _Information on what to do after an incident is resolved._
 * [Post-Mortem Process](after/post_mortem_process.md) - _Information on our post-mortem process; what's involved and how to write or run a post-mortem._
 * [Post-Mortem Template](after/post_mortem_template.md) - _The template we use for writing our post-mortems for major incidents._
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,9 +40,10 @@ pages:
     - Different Roles: 'before/different_roles.md'
     - Call Etiquette: 'before/call_etiquette.md'
   - During an Incident:
-    - During An Incident: 'during/during_an_incident.md'
+    - During an Incident: 'during/during_an_incident.md'
     - Security Incident: 'during/security_incident_response.md'
   - After an Incident:
+    - After an Incident: 'after/after_an_incident.md'
     - Post-Mortem Process: 'after/post_mortem_process.md'
     - Post-Mortem Template: 'after/post_mortem_template.md'
   - Training:


### PR DESCRIPTION
This creates a new "After an Incident" page, giving us better separation of content and allowing room for us to expand this section in future.

* Move "after" items from During an Incident to this new page, and link to it from the During an Incident page. This cuts down of there being too much information during an incident.
* Add section on reviewing the process as well as reviewing the incident.