### PR TITLE
Change glossary layout.

### DIFF
--- a/docs/before/complex_incidents.md
+++ b/docs/before/complex_incidents.md
@@ -1,4 +1,4 @@
-There will come a time when you will be involved in an incident (or multiple concurrent incidents) which ends up spanning a large number of resources. In these cases it's important for everyone to maintain an effective [span of control](../training/glossary.md). This page describes how we manage such incidents.
+There will come a time when you will be involved in an incident (or multiple concurrent incidents) which ends up spanning a large number of resources. In these cases it's important for everyone to maintain an effective [span of control](../training/glossary.md#span-of-control). This page describes how we manage such incidents.
 
 ## Identifying Complex Incidents
 Perhaps multiple issues are happening at once, or an existing incident escalated and had a knock-on effect on other services. It's important to identify these types of incidents as early as possible to prevent confusion and burn-out. Here are a few key things the Incident Commanders will be watching out for to help to identify a complex incident,

--- a/docs/during/during_an_incident.md
+++ b/docs/during/during_an_incident.md
@@ -56,7 +56,7 @@ Resolve the incident as quickly and as safely as possible, use the Deputy to ass
 1. Listen for prompts from your Deputy regarding severity escalations, decide whether we need to announce publicly, and instruct customer liaison accordingly.
     * Announcing publicly is at your discretion as IC. If you are unsure, then announce publicly ("If in doubt, tweet it out").
 
-1. Keep track of your [span of control](/training/glossary.md). If the response starts to become larger, or the incident increases in complexity, consider [splitting off sub-teams](/before/complex_incidents.md#spinning-off-sub-teams) in order to get a more effective response.
+1. Keep track of your [span of control](/training/glossary.md#span-of-control). If the response starts to become larger, or the incident increases in complexity, consider [splitting off sub-teams](/before/complex_incidents.md#spinning-off-sub-teams) in order to get a more effective response.
 
 1. Once incident has recovered or is actively recovering, you can announce that the incident is over and that the call is ending. This usually indicates there's no more productive work to be done for the incident right now.
     * Move the remaining, non-time-critical discussion to Slack.

--- a/docs/training/glossary.md
+++ b/docs/training/glossary.md
@@ -1,15 +1,34 @@
 Ever wonder what all of those strange words you sometimes see in our documentation mean? This page is here to help.
 
-| Term | Description |
-| ---- | ----------- |
-| **IC / Incident Commander** | The incident commander is the person responsible for bringing any major incident to resolution. They are the highest ranking individual on any major incident call, regardless of their day-to-day rank. Their decisions made as commander are final. [More info](../before/different_roles.md). |
-| **Deputy** | Typically the backup IC. The deputy's job is to support the IC during the call, providing them with any help they need. [More info](../before/different_roles.md). |
-| **Scribe** | The scribe's job is to keep a log of all activities performed during the call in a written chat log on Slack. [More info](../before/different_roles.md). |
-| **Resolver** | A person on the incident call who is able to help resolve issues within a particular system. Also referred to as an SME (see below). [More info](../before/different_roles.md). |
-| **SME** | "Subject Matter Expert", someone who is an expert in a particular service or subject who can provide information to the IC, and perform resolution actions for a particular system. [More info](../before/different_roles.md). |
-| **Command Staff** | The Command Staff consists of the Incident Commander, Deputy, and Scribe. |
-| **CAN Report** | CAN stands for "Conditions" "Actions" "Needs", if an IC asks you for a CAN report, you should provide the current state of your service (condition), what actions need to be taken to return it to a healthy state (actions), and what support you need in order to perform the actions (needs). |
-| **Sev / Severity** | How severe the incident is. The "sev" of an incident determines the type of response we give. The higher the severity, the higher the likelihood of making risky actions to resolve the situation. [More info](../before/severity_levels.md). |
-| **Span of Control** | Refers to the number of direct reports you have. For example, if the IC has 10 people as direct reports on a call, they have a large span of control. We aim to make the span of control as minimal as we can while still being productive. |
-| **Grenade Thrower** | Someone who joins the call at a late time in the game, and provides information that completely derails the current thinking. They then leave almost immediately. |
-| **Executive Swoop** | When an executive comes on the call and drops some sort of bombshell. A version of grenade throwing. |
+### Incident Commander / IC
+The incident commander is the person responsible for bringing any major incident to resolution. They are the highest ranking individual on any major incident call, regardless of their day-to-day rank. Their decisions made as commander are final. [More info](../before/different_roles.md).
+
+### Deputy
+Typically the backup IC. The deputy's job is to support the IC during the call, providing them with any help they need. [More info](../before/different_roles.md).
+
+### Scribe
+The scribe's job is to keep a log of all activities performed during the call in a written chat log on Slack. [More info](../before/different_roles.md).
+
+### Resolver
+A person on the incident call who is able to help resolve issues within a particular system. Also referred to as an SME (see below). [More info](../before/different_roles.md).
+
+### SME
+"Subject Matter Expert", someone who is an expert in a particular service or subject who can provide information to the IC, and perform resolution actions for a particular system. [More info](../before/different_roles.md).
+
+### Command Staff
+The Command Staff consists of the Incident Commander, Deputy, and Scribe.
+
+### CAN Report
+CAN stands for "Conditions" "Actions" "Needs", if an IC asks you for a CAN report, you should provide the current state of your service (condition), what actions need to be taken to return it to a healthy state (actions), and what support you need in order to perform the actions (needs).
+
+### Severity / Sev
+How severe the incident is. The "sev" of an incident determines the type of response we give. The higher the severity, the higher the likelihood of making risky actions to resolve the situation. [More info](../before/severity_levels.md).
+
+### Span of Control
+Refers to the number of direct reports you have. For example, if the IC has 10 people as direct reports on a call, they have a large span of control. We aim to make the span of control as minimal as we can while still being productive.
+
+### Grenade Thrower
+Someone who joins the call at a late time in the game, and provides information that completely derails the current thinking. They then leave almost immediately.
+
+### Executive Swoop
+When an executive comes on the call and drops some sort of bombshell. A version of grenade throwing.


### PR DESCRIPTION
Table works OK for our internal docs, but it's squished up on the public website and isn't very easy to read.

Changing it to headings and paragraphs so it's a) easier to read, and b) has the bonus that people can link directly to specific terms. 

I've also updated our links to point directly to the relevant terms.