### PR TITLE
Fix the YouTube links in IC training.

### DIFF
--- a/docs/training/incident_commander.md
+++ b/docs/training/incident_commander.md
@@ -240,7 +240,7 @@ PagerDuty employees have access to all previous incident calls, and can listen t
 
 ---
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/gmLgi5mdTVo" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/XLMDSjCzEx8" frameborder="0" allowfullscreen></iframe>
 Here's a clip from the movie Apollo 13, where Gene Kranz (Flight Director / Incident Commander) shows some great examples of Incident Command. Here are some things to note:
 
 * Walks into the room, and immediately obvious that he's the IC. Calms the noise, and makes sure everyone is paying attention.
@@ -255,7 +255,7 @@ Here's a clip from the movie Apollo 13, where Gene Kranz (Flight Director / Inci
 
 ---
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/KhoXFVQsIxw" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Tid44iy6Rjs" frameborder="0" allowfullscreen></iframe>
 Another clip from Apollo 13. Things to note:
 
 * Summarizes the situation, and states the facts.


### PR DESCRIPTION
The videos got moved, these are the new links.