### PR TITLE
[#62] Pin MkDocs to 0.15.3 to workaround conflicts with the theme in latest version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can view the documentation [directly](/docs/index.md) in this repository, or
 ## Development
 We use [MkDocs](http://www.mkdocs.org/) to create a static site from this repository. For local development,
 
-1. [Install MkDocs](http://www.mkdocs.org/#installation). `pip install mkdocs`
+1. Install v0.15.3 of [MkDocs](http://www.mkdocs.org/#installation). `pip install mkdocs==0.15.3`
 1. Install v0.2.4 of the [MkDocs Material theme](https://github.com/squidfunk/mkdocs-material). `pip install mkdocs-material==0.2.4`
 1. To test locally, run `mkdocs serve` from the project directory.
 


### PR DESCRIPTION
Fixes/workarounds #62.