### PR TITLE
Some style fixes for smaller devices.

### DIFF
--- a/docs/assets/css/extra.css
+++ b/docs/assets/css/extra.css
@@ -268,7 +268,7 @@ nav div.mainlogo {
 
 nav div.mainlogo a {
   min-height: 3.4em;
-  margin-bottom: -1.25em;
+  margin-bottom: -1.2em;
   width: 14.52em;
 
   background: url(/assets/img/logo.svg) 0em 0.1em no-repeat;
@@ -277,6 +277,18 @@ nav div.mainlogo a {
 
 nav div.mainlogo img {
   display: none;
+}
+
+/* Remove logo in favour of page title for smaller mobile devices. */
+@media only screen and (max-width: 480px) {
+  nav div.mainlogo {
+    width: 0em;
+  }
+
+  nav div.mainlogo a {
+    width: 4em;
+    background: none;
+  }
 }
 
 /* Admonitions */
@@ -610,6 +622,15 @@ iframe {
 
 .pagination .button .icon {
   vertical-align: .25em;
+}
+
+/* Make sure to show some previous titles even on smaller devices. */
+.pagination .previous { width: 40%; }
+.pagination .next { width: 60%; }
+
+.pagination .previous .direction,
+.pagination .previous .stretch {
+    display: table;
 }
 
 /* Super horrible hack to get the training PDF images correct */


### PR DESCRIPTION
Killing the logo in the header for small devices, since it takes up valuable horizontal space and the title is more important. We already have the icon logo on the right hand side as a link to the home page.

Before
<img width="396" src="https://user-images.githubusercontent.com/439789/33535336-e4a5e120-d861-11e7-91ce-513172e36355.png">

After
<img width="396" src="https://user-images.githubusercontent.com/439789/33535339-e75e1734-d861-11e7-9099-299710ed43dd.png">

-----

Also fixing the footer, where the back arrow was misaligned, and giving the previous section some context when it will fit.

Before
<img width="397" src="https://user-images.githubusercontent.com/439789/33535357-fe352eb6-d861-11e7-999c-4850de8a23a0.png">

After
<img width="392" src="https://user-images.githubusercontent.com/439789/33535406-375a70fc-d862-11e7-85c2-bcc6fe1b625c.png">

-----

And finally, fixing vertically misaligned logo for some devices.

![logo-misalign](https://user-images.githubusercontent.com/439789/33535423-510474c6-d862-11e7-8d51-3f0db16370d8.png)


