### PR TITLE
Pin mkdocs-bootswatch and mkdocs-bootstrap to fix build errors.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ jobs:
       - image: circleci/python:2.7.14
     steps:
       - checkout
+      - run: 'sudo pip install mkdocs-bootswatch==0.1.0'
+      - run: 'sudo pip install mkdocs-bootstrap==0.1.1'
       - run: 'sudo pip install mkdocs==0.15.3'
       - run: 'sudo pip install mkdocs-material==0.2.4'
       - run: 'sudo pip install pymdown-extensions'
@@ -17,6 +19,8 @@ jobs:
     steps:
       - checkout
       - run: 'sudo pip install awscli'
+      - run: 'sudo pip install mkdocs-bootswatch==0.1.0'
+      - run: 'sudo pip install mkdocs-bootstrap==0.1.1'
       - run: 'sudo pip install mkdocs==0.15.3'
       - run: 'sudo pip install mkdocs-material==0.2.4'
       - run: 'sudo pip install pymdown-extensions'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ You can view the documentation [directly](/docs/index.md) in this repository, or
 ## Development
 We use [MkDocs](http://www.mkdocs.org/) to create a static site from this repository. For local development,
 
+1. Install v0.1.0 of [MkDocs Bootswatch](https://github.com/mkdocs/mkdocs-bootswatch) `pip install mkdocs-bootswatch==0.1.0`
+1. Install v0.1.1 of [MkDocs Bootstrap](https://github.com/mkdocs/mkdocs-bootstrap) `pip install mkdocs-bootstrap==0.1.1`
 1. Install v0.15.3 of [MkDocs](http://www.mkdocs.org/#installation). `pip install mkdocs==0.15.3`
 1. Install v0.2.4 of the [MkDocs Material theme](https://github.com/squidfunk/mkdocs-material). `pip install mkdocs-material==0.2.4`
 1. To test locally, run `mkdocs serve` from the project directory.


### PR DESCRIPTION
The release of MkDocs 1.0 has changed some of the dependencies, so our builds now error out because it's trying to install a later version of MkDocs than we can use with our current theme. Installing `mkdocs-bootswatch` v0.1.0 and `mkdocs-boostrap` v0.1.1 _before_ trying to install mkdocs satisfies the dependencies so it doesn't attempt to install the newer version that breaks.