### PR TITLE
Fix breadcrumbs and Safari header image inconsistency.

### DIFF
--- a/docs/assets/css/extra.css
+++ b/docs/assets/css/extra.css
@@ -459,6 +459,7 @@ p.response {
   margin-top: -4em;
   margin-bottom: -2em;
   clip-path: inset(2em 0px 2em 0px);
+  -webkit-clip-path: inset(2em 0px 2em 0px); /* Safari needs the -webkit- prefix on this one. */
 }
 
 .article h1 + p + p img {

--- a/docs/assets/css/extra.css
+++ b/docs/assets/css/extra.css
@@ -126,6 +126,12 @@ ul.repo {
   content: "\e900";
 }
 
+/* Correct header navigation. */
+.bar .path a {
+  display: inline;
+  font-size: 1em;
+}
+
 /* Fix a small offset on pages with breadcrumbs. */
 .title .path .icon {
   vertical-align: -1.5px;

--- a/theme/header.html
+++ b/theme/header.html
@@ -13,7 +13,7 @@
       </div>
       <div class="title">
         <span class="{% if page_title %}path{% endif %}">
-          Incident Response
+          <a href="/">Incident Response</a>
           {% if page_title %}<i class="icon icon-link"></i>{% endif %}
         </span>
         {% if current_page %}


### PR DESCRIPTION
* Make breadcrumb clickable.
* Fix `clip-path` issue in Safari so header images look correct.