### PR TITLE
Update extension config to move away from deprecated method.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ google_analytics: ['UA-8759953-1', 'auto']
 
 # Extensions
 markdown_extensions:
-  - toc(permalink=#)
+  - toc:
+      permalink: '#'
   - sane_lists:
   - admonition:


### PR DESCRIPTION
Specifying configuration in the extension name was deprecated. This updates the config to the proper format so builds start working agian.