### PR TITLE
Add some extra links to our training course.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ cover: assets/img/covers/incident_response_docs.png
 This documentation covers parts of the PagerDuty Incident Response process. It is a cut-down version of our internal documentation, used at PagerDuty for any major incidents, and to prepare new employees for on-call responsibilities. It provides information not only on preparing for an incident, but also what to do during and after. It is intended to be used by on-call practitioners and those involved in an operational incident response process (or those wishing to enact a formal incident response process). See the [about page](about.md) for more information on what this documentation is and why it exists.
 
 !!! tip "Don't know where to start?"
-    If you're new to incident response and don't yet have a formal process in your organization, we recommend looking at our [Getting Started](/getting_started.md) page for a quick list of things you can do to begin.
+    If you're new to incident response and don't yet have a formal process in your organization, we recommend looking at our [Getting Started](/getting_started.md) page for a quick list of things you can do to begin, and our [Training Course](training/courses/incident_response.md) page for a more detailed overview of our process.
 
 ## Being On-Call
 

--- a/docs/training/courses/incident_response.md
+++ b/docs/training/courses/incident_response.md
@@ -11,7 +11,7 @@ pdf: /assets/pdf/pagerduty_incident_response_training_public.pdf
 
     It includes lots of introductory information on our process, and details on the Incident Commander role specifically. All the information is already available as part of our [public documentation](https://response.pagerduty.com) , this is just a different way of presenting it that's hopefully more engaging. Feel free to use this as a base for training in your own organization.
 
-    The text presented here is a semi-accurate transcription of how the training is usually delivered.
+    The text presented here is a semi-accurate transcription of how the training is usually delivered. You can also watch a [video](#video) of an older version of this course if you prefer.
 
 ---
 


### PR DESCRIPTION
It was pointed out that we should probably link to the training course from the getting started callout. I also added a link to the video at the top of the page.