### PR TITLE
Add PyMdown Extensions to development readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We use [MkDocs](http://www.mkdocs.org/) to create a static site from this reposi
 1. Install v0.1.1 of [MkDocs Bootstrap](https://github.com/mkdocs/mkdocs-bootstrap) `pip install mkdocs-bootstrap==0.1.1`
 1. Install v0.15.3 of [MkDocs](http://www.mkdocs.org/#installation). `pip install mkdocs==0.15.3`
 1. Install v0.2.4 of the [MkDocs Material theme](https://github.com/squidfunk/mkdocs-material). `pip install mkdocs-material==0.2.4`
-1. Install v6.0 of [MkDocs PyMdown Extensions](https://squidfunk.github.io/mkdocs-material/extensions/pymdown/). `pip install pymdown-extensions==6.0`
+1. Install [MkDocs PyMdown Extensions](https://squidfunk.github.io/mkdocs-material/extensions/pymdown/). `pip install pymdown-extensions`
 1. To test locally, run `mkdocs serve` from the project directory.
 
 ## Deploying

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ We use [MkDocs](http://www.mkdocs.org/) to create a static site from this reposi
 1. Install v0.1.1 of [MkDocs Bootstrap](https://github.com/mkdocs/mkdocs-bootstrap) `pip install mkdocs-bootstrap==0.1.1`
 1. Install v0.15.3 of [MkDocs](http://www.mkdocs.org/#installation). `pip install mkdocs==0.15.3`
 1. Install v0.2.4 of the [MkDocs Material theme](https://github.com/squidfunk/mkdocs-material). `pip install mkdocs-material==0.2.4`
+1. Install v6.0 of [MkDocs PyMdown Extensions](https://squidfunk.github.io/mkdocs-material/extensions/pymdown/). `pip install pymdown-extensions==6.0`
 1. To test locally, run `mkdocs serve` from the project directory.
 
 ## Deploying


### PR DESCRIPTION
I was trying to build this locally and ran into this error:

```
INFO    -  Building documentation... 
INFO    -  Cleaning site directory 
ERROR   -  Error building page index.md 
Traceback (most recent call last):
  File "/usr/local/bin/mkdocs", line 11, in <module>
    sys.exit(cli())
  File "/Library/Python/2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Library/Python/2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Library/Python/2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Library/Python/2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Library/Python/2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Library/Python/2.7/site-packages/mkdocs/__main__.py", line 115, in serve_command
    livereload=livereload,
  File "/Library/Python/2.7/site-packages/mkdocs/commands/serve.py", line 78, in serve
    config = builder()
  File "/Library/Python/2.7/site-packages/mkdocs/commands/serve.py", line 74, in builder
    build(config, live_server=True, clean_site_dir=True)
  File "/Library/Python/2.7/site-packages/mkdocs/commands/build.py", line 289, in build
    build_pages(config)
  File "/Library/Python/2.7/site-packages/mkdocs/commands/build.py", line 249, in build_pages
    dump_json)
  File "/Library/Python/2.7/site-packages/mkdocs/commands/build.py", line 169, in _build_page
    site_navigation=site_navigation
  File "/Library/Python/2.7/site-packages/mkdocs/commands/build.py", line 35, in convert_markdown
    extension_configs=config['mdx_configs']
  File "/Library/Python/2.7/site-packages/mkdocs/utils/__init__.py", line 337, in convert_markdown
    extension_configs=extension_configs or {}
  File "/Library/Python/2.7/site-packages/markdown/core.py", line 100, in __init__
    configs=kwargs.get('extension_configs', {}))
  File "/Library/Python/2.7/site-packages/markdown/core.py", line 126, in registerExtensions
    ext = self.build_extension(ext, configs.get(ext, {}))
  File "/Library/Python/2.7/site-packages/markdown/core.py", line 166, in build_extension
    module = importlib.import_module(ext_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
ImportError: Failed loading extension "pymdownx.details".
```

After running `pip install pymdown-extensions==6.0` it solved it and I can build locally, I don't know if it's the desired version. But it works for me