### PR TITLE
Add example incident recording to training overview page.

### DIFF
--- a/docs/assets/css/extra.css
+++ b/docs/assets/css/extra.css
@@ -735,7 +735,7 @@ iframe {
 #national-incident-management-system-nims ~ p img {
   display: inline;
 }
-#national-incident-management-system-nims ~ p:nth-of-type(7) {
+#national-incident-management-system-nims ~ p:nth-of-type(8) {
   text-align: center;
 }
 

--- a/docs/training/overview.md
+++ b/docs/training/overview.md
@@ -20,6 +20,11 @@ We've also published slides and videos of some of our training courses. Original
 
 * [Incident Response Training Course](/training/courses/incident_response.md) - Introductory course on incident response and the role of the Incident Commander.
 
+## Example Incident
+This recorded call is a reenactment of an actual major incident that occurred at PagerDuty in [January 2017](https://status.pagerduty.com/incidents/510k1bnvwv6g). Some details have been changed in the interest of brevity and privacy, but the incident remains otherwise largely intact. For more details about the recording, you can read the [PagerDuty blog post](https://www.pagerduty.com/blog/incident-response-reenactment/).
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/vw6I5DYWkNA?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+
 ## National Incident Management System (NIMS)
 Our incident response process is loosely based on the [US National Incident Management System (NIMS)](https://www.fema.gov/national-incident-management-system), which is described as,
 


### PR DESCRIPTION
This adds the example incident call from https://www.pagerduty.com/blog/incident-response-reenactment/ to our training overview page.